### PR TITLE
Remove useless API calls to CKAN

### DIFF
--- a/src/main/java/org/ozwillo/dcexporter/model/ui/AuditLogWapper.java
+++ b/src/main/java/org/ozwillo/dcexporter/model/ui/AuditLogWapper.java
@@ -21,14 +21,11 @@ public class AuditLogWapper {
 
     @JsonProperty
     private String datasetUrl;
-    @JsonProperty
-    private String organizationName;
-
-    public AuditLogWapper(DcModelMapping dcModelMapping, SynchronizerAuditLog synchronizerAuditLog, String datasetUrl, String organizationName) {
+    
+    public AuditLogWapper(DcModelMapping dcModelMapping, SynchronizerAuditLog synchronizerAuditLog, String datasetUrl) {
         this.dcModelMapping = dcModelMapping;
         this.synchronizerAuditLog = synchronizerAuditLog;
         this.datasetUrl = datasetUrl;
-        this.organizationName = organizationName;
     }
 
     public DcModelMapping getDcModelMapping() {

--- a/src/main/java/org/ozwillo/dcexporter/service/DcModelMappingService.java
+++ b/src/main/java/org/ozwillo/dcexporter/service/DcModelMappingService.java
@@ -4,7 +4,6 @@ import javaslang.control.Either;
 import org.joda.time.DateTime;
 import org.ozwillo.dcexporter.dao.DcModelMappingRepository;
 import org.ozwillo.dcexporter.dao.SynchronizerAuditLogRepository;
-import org.ozwillo.dcexporter.model.Ckan.CkanOrganization;
 import org.ozwillo.dcexporter.model.Ckan.CkanResource;
 import org.ozwillo.dcexporter.model.DcModelMapping;
 import org.ozwillo.dcexporter.model.SynchronizerStatus;
@@ -15,9 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -124,14 +121,7 @@ public class DcModelMappingService {
                 .map(dcModelMapping -> {
                     SynchronizerAuditLog auditLog = synchronizerAuditLogRepository.findFirstByTypeOrderByDateDesc(dcModelMapping.getType());
                     String datasetUrl = ckanUrl  + "/dataset/" + dcModelMapping.getUrl();
-                    String organizationName = "";
-                    if (!StringUtils.isEmpty(dcModelMapping.getOrganizationId()) ) {
-                        Either<String, CkanOrganization> eitherOrganization = ckanService.getOrganization(dcModelMapping.getOrganizationId());
-                        if (eitherOrganization.isRight()) {
-                            organizationName = eitherOrganization.get().getDisplayName();
-                        }
-                    }
-                    return new AuditLogWapper(dcModelMapping, auditLog, datasetUrl, organizationName);
+                    return new AuditLogWapper(dcModelMapping, auditLog, datasetUrl);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
I removed API calls to CKAN for each DcModelMapping found in DB.
These calls were used to retrieve organization name but this name is never in the front