### PR TITLE
Add frequency extra field (with fixed value) for resources

### DIFF
--- a/src/main/java/org/ozwillo/dcexporter/model/Ckan/CkanResource.java
+++ b/src/main/java/org/ozwillo/dcexporter/model/Ckan/CkanResource.java
@@ -48,12 +48,12 @@ public class CkanResource {
     private String openspendingHint;
     @JsonIgnore
     private byte[] upload;
-
+    private String frequency = "Real time"; // default fixed value
 
     public CkanResource() {
     }
 
-    public CkanResource(String cacheLastUpdated, String packageId, String webstoreLastUpdated, boolean datastoreActive, String id, String size, String state, String hash, String description, String format, String lastModified, String urlType, String mimetype, String cacheUrl, String name, String created, String url, String webstoreUrl, String mimetypeInner, int position, String revisionId, String resourceType, String openspendingHint, byte[] upload) {
+    public CkanResource(String cacheLastUpdated, String packageId, String webstoreLastUpdated, boolean datastoreActive, String id, String size, String state, String hash, String description, String format, String lastModified, String urlType, String mimetype, String cacheUrl, String name, String created, String url, String webstoreUrl, String mimetypeInner, int position, String revisionId, String resourceType, String openspendingHint, byte[] upload, String frequency) {
         this.cacheLastUpdated = cacheLastUpdated;
         this.packageId = packageId;
         this.webstoreLastUpdated = webstoreLastUpdated;
@@ -78,6 +78,7 @@ public class CkanResource {
         this.resourceType = resourceType;
         this.openspendingHint = openspendingHint;
         this.upload = upload;
+        this.frequency = frequency;
     }
 
 
@@ -263,4 +264,13 @@ public class CkanResource {
             this.size = String.valueOf(upload.length);
         }
     }
+
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+    
 }

--- a/src/main/java/org/ozwillo/dcexporter/service/CkanClientService.java
+++ b/src/main/java/org/ozwillo/dcexporter/service/CkanClientService.java
@@ -152,6 +152,7 @@ public class CkanClientService {
                 .addFormDataPart("last_modified", ckanResource.getLastModified())
                 .addFormDataPart("upload", ckanResource.getName(),
                         RequestBody.create(MediaType.parse("application/octet-stream; charset=utf-8"), ckanResource.getUpload()))
+                .addFormDataPart("frequency", ckanResource.getFrequency())
                 .build();
 
         CkanAPI ckanAPI = getCkanAPI(ckanUrl);


### PR DESCRIPTION
Nothing done for source as a `source` text field is already present while creating a new dataset.
This value is then set to `url` field during Ckan api call, which is designed for.

Extract from Ckan  [`package_create`](http://docs.ckan.org/en/ckan-2.7.3/api/#ckan.logic.action.create.package_create) method : 
```
url (string) – a URL for the dataset’s source (optional)
```